### PR TITLE
added badge to cart menu icon

### DIFF
--- a/client/src/components/MenuButton.tsx
+++ b/client/src/components/MenuButton.tsx
@@ -2,6 +2,7 @@ import { Nav, Stack } from "react-bootstrap";
 import { CgHome, CgUser, CgShoppingCart } from "react-icons/cg";
 import { HiOutlineTicket } from "react-icons/hi";
 import { HiOutlineEnvelope } from "react-icons/hi2";
+import ProductsInCartBadge from "./ProductsInCartBadge";
 
 interface MenuItemType {
   menuItemType: string;
@@ -47,6 +48,7 @@ const MenuButton = ({ menuItemType }: MenuItemType) => {
           <CgShoppingCart key={menuItemType + "icon"} className={ICON_CLASS_NAME} />,
           <span key={menuItemType + "label"} className={LABEL_CLASS_NAME}>
             Cart
+            <ProductsInCartBadge/>
           </span>,
         ];
     }

--- a/client/src/components/ProductsInCartBadge.tsx
+++ b/client/src/components/ProductsInCartBadge.tsx
@@ -1,0 +1,13 @@
+import { useSelector } from "react-redux";
+import { Badge } from "react-bootstrap";
+
+const ProductsInCartBadge = () => {
+  const { cartItems } = useSelector((state: any) => state.cart);
+  return cartItems.length > 0 ? (
+    <Badge pill bg="success" className="ms-1">
+      {cartItems.reduce((acc: number, item: any) => acc + item.chosenTicketsAmount, 0)}
+    </Badge>
+  ) : null;
+};
+
+export default ProductsInCartBadge;

--- a/client/src/screens/Product.tsx
+++ b/client/src/screens/Product.tsx
@@ -19,7 +19,7 @@ const Product = () => {
   const [chosenTicketsAmount, setChosenTicketsAmount] = useState<number>(1);
 
   const handleTicketsSelect = (e: any) => {
-    setChosenTicketsAmount(e.target.value);
+    setChosenTicketsAmount(Number(e.target.value));
   };
 
   const addToCartHandler = () => {


### PR DESCRIPTION
https://portugez.monday.com/boards/4584533732/pulses/4775383613
adding small badge to cart icon that show the amount of tickets in cart

when cart is empty (before):
![image](https://github.com/ChipLuxury-EWA/show-time/assets/53507364/98f87674-abfb-4df9-b6c8-4a93dfd912f4)

when cart includes items: (after):
![image](https://github.com/ChipLuxury-EWA/show-time/assets/53507364/f0c13f91-9212-43e8-ba8d-f66831d98272)
