### PR TITLE
Feat/tompo/frontend auth and endpoints

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,6 +25,7 @@
         "react-redux": "^8.1.1",
         "react-router-dom": "^6.12.0",
         "react-scripts": "5.0.1",
+        "react-toastify": "^9.1.3",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
@@ -5919,6 +5920,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14748,6 +14757,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "react-redux": "^8.1.1",
     "react-router-dom": "^6.12.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^9.1.3",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2,3 +2,8 @@ body {
   padding-top: 10px;
   padding-bottom: 80px; /*space for navbar*/
 }
+
+/* cancel little arrow after profile dropdown menu */
+#profile-dropdown::after {
+  display: none !important; 
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,6 @@
 import { Container } from "react-bootstrap";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import "./App.css";
 import { Outlet } from "react-router-dom";
 import Footer from "./components/Footer";
@@ -10,6 +12,7 @@ function App() {
         <Outlet />
         <Footer />
       </Container>
+      <ToastContainer />
     </div>
   );
 }

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { Navbar, Nav, Container } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import MenuButton from "./MenuButton";
+import ProfileButton from "./ProfileButton";
 
 const Footer = () => {
   const navigate = useNavigate();
@@ -9,7 +10,7 @@ const Footer = () => {
     navigate(`/${eventKey}`);
     console.log(`pressed ${eventKey}`); // TODO tompo add event logger
   };
-  const menuItemsTypes = ["home", "inbox", "myShows", "profile", "cart"];
+  const menuItemsTypes = ["home", "inbox", "myShows", "cart"];
   const menuItemsDynamicList = menuItemsTypes.map((type) => (
     <MenuButton key={type} menuItemType={type} />
   ));
@@ -27,6 +28,7 @@ const Footer = () => {
             }}
           >
             {menuItemsDynamicList}
+            <ProfileButton/>
           </Nav>
         </Container>
       </Navbar>

--- a/client/src/components/FormContainer.tsx
+++ b/client/src/components/FormContainer.tsx
@@ -1,0 +1,15 @@
+import { Container, Row, Col } from "react-bootstrap";
+
+const FormContainer = ({ children }: any) => {
+  return (
+    <Container>
+      <Row className="justify-content-md-center">
+        <Col xs={12} md={6}>
+          {children}
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default FormContainer;

--- a/client/src/components/Loader.tsx
+++ b/client/src/components/Loader.tsx
@@ -1,13 +1,24 @@
 import { Spinner } from "react-bootstrap";
 
-const Loader = () => {
-  return (
-    <Spinner
-      animation="border"
-      role="status"
-      style={{ width: "150px", height: "150px", margin: "auto", display: "block", marginTop: "40vh" }}
-    />
-  );
+const Loader = ({
+  width,
+  height,
+  margin,
+  marginTop,
+}: {
+  width: string;
+  height: string;
+  margin: string;
+  marginTop: string;
+}) => {
+  return <Spinner animation="border" role="status" style={{ width, height, margin, display: "block", marginTop }} />;
+};
+
+Loader.defaultProps = {
+  width: "150px",
+  height: "150px",
+  margin: "auto",
+  marginTop: "40vh",
 };
 
 export default Loader;

--- a/client/src/components/MenuButton.tsx
+++ b/client/src/components/MenuButton.tsx
@@ -1,5 +1,5 @@
 import { Nav, Stack } from "react-bootstrap";
-import { CgHome, CgUser, CgShoppingCart } from "react-icons/cg";
+import { CgHome, CgShoppingCart } from "react-icons/cg";
 import { HiOutlineTicket } from "react-icons/hi";
 import { HiOutlineEnvelope } from "react-icons/hi2";
 import ProductsInCartBadge from "./ProductsInCartBadge";
@@ -34,13 +34,6 @@ const MenuButton = ({ menuItemType }: MenuItemType) => {
           <HiOutlineTicket key={menuItemType + "icon"} className={ICON_CLASS_NAME} />,
           <span key={menuItemType + "label"} className={LABEL_CLASS_NAME}>
             My Shows
-          </span>,
-        ];
-      case "profile":
-        return [
-          <CgUser key={menuItemType + "icon"} className={ICON_CLASS_NAME} />,
-          <span key={menuItemType + "label"} className={LABEL_CLASS_NAME}>
-            Profile
           </span>,
         ];
       case "cart":

--- a/client/src/components/ProfileButton.tsx
+++ b/client/src/components/ProfileButton.tsx
@@ -1,0 +1,42 @@
+import { useSelector } from "react-redux";
+import { CgUser } from "react-icons/cg";
+import { Nav, NavDropdown, Stack } from "react-bootstrap";
+
+const IconAndName = ({ name }: { name: string }) => {
+  return (
+    <Stack>
+      <CgUser className="align-self-center" />
+      {name}
+    </Stack>
+  );
+};
+
+const ProfileButton = () => {
+  const { userInfo } = useSelector((state: any) => state.auth);
+
+  const logoutHandler = () => {
+    console.log("Logging out fe - profileButton.tsx");
+  };
+
+  return (
+    <>
+      {userInfo ? (
+        <NavDropdown id="profile-dropdown" drop="up" title={<IconAndName name={userInfo.name} />}>
+          <NavDropdown.Item eventKey="profile">Profile</NavDropdown.Item>
+          <NavDropdown.Item onClick={logoutHandler}>Logout</NavDropdown.Item>
+        </NavDropdown>
+      ) : (
+        <Nav.Item>
+          <Nav.Link eventKey="user/login">
+            <Stack className="align-items-end">
+              <CgUser className="align-self-center" />
+              <span className="align-self-center text-nowrap">Login</span>
+            </Stack>
+          </Nav.Link>
+        </Nav.Item>
+      )}
+    </>
+  );
+};
+
+export default ProfileButton;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -15,6 +15,7 @@ import MyShows from "./screens/MyShows";
 import Profile from "./screens/Profile";
 import Product from "./screens/Product";
 import Cart from "./screens/Cart";
+import Login from "./screens/Login";
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -26,7 +27,10 @@ const router = createBrowserRouter(
       <Route path="/product">
         <Route path=":id" element={<Product />} />
       </Route>
-      <Route path="/cart" element={<Cart />}/>
+      <Route path="/cart" element={<Cart />} />
+      <Route path="/user">
+        <Route path="login" element={<Login />} />
+      </Route>
     </Route>
   )
 );

--- a/client/src/redux/constants/api.constants.ts
+++ b/client/src/redux/constants/api.constants.ts
@@ -1,6 +1,6 @@
 export const BASE_URL = ""; // base url is empty because we using proxy to http://localhost:3001
 export const API_VERSION = "/api/v1";
 export const SHOWS_URL = `${API_VERSION}/shows`;
-export const USERS_URL = `${API_VERSION}/users`;
+export const USER_URL = `${API_VERSION}/user`;
 export const ORDERS_URL = `${API_VERSION}/orders`;
 export const PAYPAL_URL = `${API_VERSION}/config/paypal`;

--- a/client/src/redux/slices/auth.slice.ts
+++ b/client/src/redux/slices/auth.slice.ts
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { setCredentialsUtil } from "../utils/auth.utils";
+
+interface IInitialState {
+  userInfo: any;
+}
+
+const getUserInfoFromLocalStorage = (): string | null => {
+  const userInfo = localStorage.getItem("userInfo");
+  return userInfo ? JSON.parse(userInfo) : null;
+};
+
+const initialState: IInitialState = {
+  userInfo: getUserInfoFromLocalStorage(),
+};
+
+const authSlice: any = createSlice({
+  name: "auth",
+  initialState,
+  reducers: { setCredentials: (state, action) => setCredentialsUtil(state, action) },
+});
+
+export const { setCredentials } = authSlice.actions;
+export default authSlice.reducer;

--- a/client/src/redux/slices/userApi.slice.ts
+++ b/client/src/redux/slices/userApi.slice.ts
@@ -1,0 +1,32 @@
+import { USERS_URL } from "../constants/api.constants";
+import { apiSlice } from "./api.slice";
+
+export enum UserRoleEnum {
+  ADMIN = "ADMIN",
+  SHOW_ORGANIZER = "SHOW_ORGANIZER",
+  BUYER = "BUYER",
+}
+
+export interface IUserDetails {
+  _id: string;
+  name: string;
+  email: string;
+  role: keyof typeof UserRoleEnum;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export const userApiSlice = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    login: builder.mutation<[IUserDetails], void>({
+      //TODO tompo add the right type here - replace void
+      query: (data) => ({
+        url: `${USERS_URL}/auth`,
+        method: "POST",
+        body: data,
+      }),
+    }),
+  }),
+});
+
+export const { useLoginMutation } = userApiSlice;

--- a/client/src/redux/slices/userApi.slice.ts
+++ b/client/src/redux/slices/userApi.slice.ts
@@ -1,4 +1,4 @@
-import { USERS_URL } from "../constants/api.constants";
+import { USER_URL } from "../constants/api.constants";
 import { apiSlice } from "./api.slice";
 
 export enum UserRoleEnum {
@@ -7,21 +7,17 @@ export enum UserRoleEnum {
   BUYER = "BUYER",
 }
 
-export interface IUserDetails {
-  _id: string;
-  name: string;
+export interface IUserDetailsForLogin {
   email: string;
-  role: keyof typeof UserRoleEnum;
-  createdAt?: string;
-  updatedAt?: string;
+  password: string;
 }
 
 export const userApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    login: builder.mutation<[IUserDetails], void>({
+    login: builder.mutation<[IUserDetailsForLogin], IUserDetailsForLogin>({
       //TODO tompo add the right type here - replace void
       query: (data) => ({
-        url: `${USERS_URL}/auth`,
+        url: `${USER_URL}/login`,
         method: "POST",
         body: data,
       }),

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -1,9 +1,15 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { apiSlice } from "./slices/api.slice";
 import cartSliceReducer from "./slices/cart.slice";
+import authSliceReducer from "./slices/auth.slice";
 
 const store = configureStore({
-  reducer: { [apiSlice.reducerPath]: apiSlice.reducer, cart: cartSliceReducer },
+  reducer: {
+    [apiSlice.reducerPath]: apiSlice.reducer,
+    cart: cartSliceReducer,
+    auth: authSliceReducer,
+  },
+
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(apiSlice.middleware),
   devTools: true,
 });

--- a/client/src/redux/utils/auth.utils.ts
+++ b/client/src/redux/utils/auth.utils.ts
@@ -1,0 +1,4 @@
+export const setCredentialsUtil = (state: any, action: any) => {
+  state.userInfo = action.payload;
+  localStorage.setItem("userInfo", JSON.stringify(action.payload));
+};

--- a/client/src/redux/utils/auth.utils.ts
+++ b/client/src/redux/utils/auth.utils.ts
@@ -1,4 +1,4 @@
 export const setCredentialsUtil = (state: any, action: any) => {
-  state.userInfo = action.payload;
+  state.userInfo = {...action.payload};
   localStorage.setItem("userInfo", JSON.stringify(action.payload));
 };

--- a/client/src/screens/Login.tsx
+++ b/client/src/screens/Login.tsx
@@ -61,14 +61,21 @@ const Login = () => {
             onChange={(e) => setPassword(e.target.value)}
           ></Form.Control>
         </Form.Group>
-        <Button type="submit" variant="primary" className="mt-2">
-          Sign in
-        </Button>
+        <Form.Group>
+          <Row xs="auto">
+            <Col>
+              <Button type="submit" variant="primary" className="mt-2" disabled={isLoading}>
+                Sign in
+              </Button>
+            </Col>
+            <Col>{isLoading && <Loader height="30px" width="30px" marginTop="11px" />}</Col>
+          </Row>
+        </Form.Group>
       </Form>
 
       <Row className="py-3">
         <Col>
-          New Customer? <Link to="/register">Register now!</Link>
+          New Customer? <Link to={redirect ? `/register?redirect=${redirect}` : "/register"}>Register now!</Link>
         </Col>
       </Row>
     </FormContainer>

--- a/client/src/screens/Login.tsx
+++ b/client/src/screens/Login.tsx
@@ -1,15 +1,42 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import { Form, Button, Row, Col } from "react-bootstrap";
 import FormContainer from "../components/FormContainer";
+import Loader from "../components/Loader";
+import { useLoginMutation } from "../redux/slices/userApi.slice";
+import { setCredentials } from "../redux/slices/auth.slice";
+import { toast } from "react-toastify";
 
 const Login = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const { userInfo } = useSelector((state: any) => state.auth);
+  const [login, { isLoading }] = useLoginMutation();
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  const submitHandler = (e: any): void => {
+  const { search } = useLocation();
+  const searchParams = new URLSearchParams(search);
+  const redirect = searchParams.get("redirect") || "/home";
+
+  useEffect(() => {
+    if (userInfo) {
+      navigate(redirect);
+    }
+  }, [userInfo, redirect, navigate]);
+
+  const submitHandler = async (e: any) => {
     e.preventDefault();
-    console.log("submit");
+    try {
+      const answer = await login({ email, password }).unwrap();
+      dispatch(setCredentials(answer));
+      navigate(redirect);
+    } catch (error: any) {
+      toast.error(error?.data?.message || error?.error);
+    }
   };
 
   return (

--- a/client/src/screens/Login.tsx
+++ b/client/src/screens/Login.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Form, Button, Row, Col } from "react-bootstrap";
+import FormContainer from "../components/FormContainer";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const submitHandler = (e: any): void => {
+    e.preventDefault();
+    console.log("submit");
+  };
+
+  return (
+    <FormContainer>
+      <h1>Sign in</h1>
+      <Form onSubmit={submitHandler}>
+        <Form.Group controlId="email" className="my-3">
+          <Form.Label>Email Address</Form.Label>
+          <Form.Control
+            type="email"
+            placeholder="Enter email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          ></Form.Control>
+        </Form.Group>
+        <Form.Group controlId="password" className="my-3">
+          <Form.Label>Password</Form.Label>
+          <Form.Control
+            type="password"
+            placeholder="Enter password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          ></Form.Control>
+        </Form.Group>
+        <Button type="submit" variant="primary" className="mt-2">
+          Sign in
+        </Button>
+      </Form>
+
+      <Row className="py-3">
+        <Col>
+          New Customer? <Link to="/register">Register now!</Link>
+        </Col>
+      </Row>
+    </FormContainer>
+  );
+};
+
+export default Login;

--- a/server/src/api/user_v1.http
+++ b/server/src/api/user_v1.http
@@ -19,8 +19,8 @@ POST {{BASE_URL}}/user/login HTTP/1.1 HTTP/1.1
 Content-Type: application/json
 
 {
-  "userEmail": "{{EMAIL}}",
-  "userPassword": "{{password_1}}"
+  "email": "{{EMAIL}}",
+  "password": "{{password_1}}"
 }
 ###
 
@@ -29,8 +29,8 @@ POST {{BASE_URL}}/user/login HTTP/1.1 HTTP/1.1
 Content-Type: application/json
 
 {
-  "userEmail": "{{BUYER_EMAIL}}",
-  "userPassword": "{{password_1}}"
+  "email": "{{BUYER_EMAIL}}",
+  "password": "{{password_1}}"
 }
 ###
 


### PR DESCRIPTION
added client login page and auth end points
improved profile menu button.

if user is not sign in he will see login button:
![image](https://github.com/ChipLuxury-EWA/show-time/assets/53507364/0f938ded-94c4-4a93-ac98-13637a7727e5)
then he will get to this page:
![image](https://github.com/ChipLuxury-EWA/show-time/assets/53507364/9d0fdad2-4295-4ea4-ba85-6638c26d67bf)
error in email or password:
![image](https://github.com/ChipLuxury-EWA/show-time/assets/53507364/2f393651-695d-4bef-8db3-d3fe6393c0e0)
when success login user will redirect to home page

when user loged in he will see his name and press on that will open dropdown menu:
![image](https://github.com/ChipLuxury-EWA/show-time/assets/53507364/363773a2-0f9b-49c7-94ef-5d821c1323bc)
when user press on 'profile' it will take him to profile page
